### PR TITLE
Note about starting fig-elk when SELinux is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Based on 3 Docker images:
 2. Install [Docker-compose](http://docs.docker.com/compose/install/).
 3. Clone this repository
 4. Update the logstash-configuration in logstash-conf/logstash.conf (test your filters here)
-5. docker-compose up
+5. docker-compose up (-d to run detached in the background)
 6. nc localhost 5000 < /some/log/file.log
 7. http://localhost:8080 to see the messages show up in Kibana 3.
 8. http://localhost:5601 to use Kibana 4.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Based on 3 Docker images:
 1. Install [Docker](http://docker.io).
 2. Install [Docker-compose](http://docs.docker.com/compose/install/).
 3. Clone this repository
+
+NOTE: on distributions which have SELinux enabled out-of-the-box you will need to either
+re-context the files or set SELinux into Permissive mode in order for fig-elk to start
+properly. For example on Redhat and CentOS, the following will apply the proper context:
+```
+.-root@centos ~
+`-$ chcon -R system_u:object_r:admin_home_t:s0 fig-elk/
+```
+
 4. Update the logstash-configuration in logstash-conf/logstash.conf (test your filters here)
 5. docker-compose up (-d to run detached in the background)
 6. nc localhost 5000 < /some/log/file.log


### PR DESCRIPTION
Centos|Redhat is used in the example since that was the type of distribution I was on. Regardless, the note should point future readers, who might be in the same predicament, in the right direction.