### PR TITLE
Use official images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Run the ELK (Elasticseach, Logstash, Kibana) stack with Docker and Docker-compos
 
 It will give you the ability to quickly test your logstash filters and check how the data can be processed in Kibana.
 
-Based on the 3 following Docker images:
+Based on the official images:
 
-* [elk-elasticsearch](https://github.com/deviantony/docker-elk-elasticsearch)
-* [elk-logstash](https://github.com/deviantony/docker-elk-logstash)
-* [elk-kibana](https://github.com/deviantony/docker-elk-kibana)
+* [elasticsearch](https://registry.hub.docker.com/_/elasticsearch/)
+* [logstash](https://registry.hub.docker.com/_/logstash/)
+* [kibana](https://registry.hub.docker.com/_/kibana/)
 
 # HOW TO
 
@@ -20,9 +20,9 @@ Based on the 3 following Docker images:
 2. Install [Docker-compose](http://docs.docker.com/compose/install/).
 3. Clone this repository
 
-### SELinux 
+### SELinux
 
-On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux into Permissive mode in order for fig-elk to start properly. 
+On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux into Permissive mode in order for fig-elk to start properly.
 For example on Redhat and CentOS, the following will apply the proper context:
 
 ```
@@ -61,7 +61,6 @@ The stack exposes 4 ports on your localhost:
 
 * 5000: Logstash TCP input.
 * 9200: Elasticsearch HTTP (with Marvel plugin accessible via [http://localhost:9200/_plugin/marvel](http://localhost:9200/_plugin/marvel))
-* 8080: Kibana 3 web interface, access it via [http://localhost:8080](http://localhost:8080)
 * 5601: Kibana 4 web interface, access it via [http://localhost:5601](http://localhost:5601)
 
 
@@ -69,5 +68,4 @@ The stack exposes 4 ports on your localhost:
 
 If you're using *boot2docker*, you must access it via the *boot2docker* IP address:
 * http://boot2docker-ip-address:9200/_plugin/marvel to access the Marvel plugin.
-* http://boot2docker-ip-address:8080 to use Kibana 3.
 * http://boot2docker-ip-address:5601 to use Kibana 4.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,18 @@
 elasticsearch:
-  image: deviantony/elk-elasticsearch
+  build: elasticsearch/
   ports:
     - "9200:9200"
 logstash:
-  image: deviantony/elk-logstash
+  image: logstash:latest
+  command: logstash -f /etc/logstash/conf.d/logstash.conf
   volumes:
     - logstash-conf:/etc/logstash/conf.d
   ports:
-    - "5000:5000"  
+    - "5000:5000"
   links:
     - elasticsearch
-kibana3:
-  image: deviantony/elk-kibana:kibana3
-  ports:
-    - "8080:80"
-  links:
-    - elasticsearch
-kibana4:
-  image: deviantony/elk-kibana
+kibana:
+  build: kibana/
   ports:
     - "5601:5601"
   links:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,3 @@
+FROM elasticsearch:latest
+
+RUN plugin -i elasticsearch/marvel/latest

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,0 +1,9 @@
+FROM kibana:latest
+
+RUN apt-get update && apt-get install -y netcat
+
+COPY config/kibana.yml /opt/kibana/config/kibana.yml
+COPY entrypoint.sh /tmp/entrypoint.sh
+RUN chmod +x /tmp/entrypoint.sh
+
+CMD ["/tmp/entrypoint.sh"]

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -1,0 +1,76 @@
+# Kibana is served by a back end server. This controls which port to use.
+port: 5601
+
+# The host to bind the server to.
+host: "0.0.0.0"
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch_url: "http://elasticsearch:9200"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch_preserve_host: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana_index: ".kibana"
+
+# If your Elasticsearch is protected with basic auth, this is the user credentials
+# used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied thorugh
+# the Kibana server)
+# kibana_elasticsearch_username: user
+# kibana_elasticsearch_password: pass
+
+# If your Elasticsearch requires client certificate and key
+# kibana_elasticsearch_client_crt: /path/to/your/client.crt
+# kibana_elasticsearch_client_key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsarech instance, put
+# the path of the pem file here.
+# ca: /path/to/your/CA.pem
+
+# The default application to load.
+default_app_id: "discover"
+
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# ping_timeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+request_timeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+shard_timeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+# startup_timeout: 5000
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# SSL for outgoing requests from the Kibana Server (PEM formatted)
+# ssl_key_file: /path/to/your/server.key
+# ssl_cert_file: /path/to/your/server.crt
+
+# Set the path to where you would like the process id file to be created.
+# pid_file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# This will also turn off the STDOUT log output.
+# log_file: ./kibana.log
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundled_plugin_ids:
+ - plugins/dashboard/index
+ - plugins/discover/index
+ - plugins/doc/index
+ - plugins/kibana/index
+ - plugins/markdown_vis/index
+ - plugins/metric_vis/index
+ - plugins/settings/index
+ - plugins/table_vis/index
+ - plugins/vis_types/index
+ - plugins/visualize/index

--- a/kibana/entrypoint.sh
+++ b/kibana/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Wait for the Elasticsearch container to be ready before starting Kibana.
+echo "Stalling for Elasticsearch"
+while true; do
+    nc -q 1 elasticsearch 9200 2>/dev/null && break
+done
+
+echo "Starting Kibana"
+kibana

--- a/logstash-conf/logstash.conf
+++ b/logstash-conf/logstash.conf
@@ -4,12 +4,8 @@ input {
 	}
 }
 
-# Add your filters here
+## Add your filters here
 
-# Must use http protocol and specify the host to use Kibana4
 output {
-	elasticsearch { 
-		protocol => "http"
-		host => "elasticsearch"
-	}
+	elasticsearch { }
 }


### PR DESCRIPTION
Replaced logstash image with latest official image.
Manages elasticsearch container using the latest official image inside this repository.
Manages the kibana container using the latest official image inside this repository.
Updated README.
Close #1 